### PR TITLE
Add support for compression via rust-snappy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,14 @@ keywords = ["voxel"]
 [features]
 default = []
 
+bincode_snappy = ["bincode", "serde", "snap"]
 bincode_lz4 = ["bincode", "lz4", "serde"]
 
 [dependencies]
 bincode = { version = "1.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+snap = { version = "1.0.3", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.7"

--- a/src/bincode_snappy.rs
+++ b/src/bincode_snappy.rs
@@ -1,0 +1,77 @@
+use crate::{Compressible, Decompressible};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// A fast and portable compression scheme for use with the `CompressibleMap`.
+#[derive(Clone, Copy, Debug)]
+pub struct BincodeSnappy;
+
+#[derive(Deserialize, Serialize)]
+pub struct BincodeSnappyCompressed<T> {
+    pub compressed_bytes: Vec<u8>,
+    marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Compressible<BincodeSnappy> for T
+where
+    T: DeserializeOwned + Serialize,
+{
+    type Compressed = BincodeSnappyCompressed<T>;
+
+    fn compress(&self, _params: BincodeSnappy) -> Self::Compressed {
+        let serialized_bytes = bincode::serialize(&self).unwrap();
+
+        let mut encoder = snap::write::FrameEncoder::new(Vec::new());
+
+        std::io::copy(&mut std::io::Cursor::new(serialized_bytes), &mut encoder).unwrap();
+        let compressed_bytes = encoder.into_inner().expect("failed to flush the writer");
+
+        BincodeSnappyCompressed {
+            compressed_bytes,
+            marker: Default::default(),
+        }
+    }
+}
+
+impl<T> Decompressible<BincodeSnappy> for BincodeSnappyCompressed<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    type Decompressed = T;
+
+    fn decompress(&self) -> Self::Decompressed {
+        let mut decoder = snap::read::FrameDecoder::new(self.compressed_bytes.as_slice());
+        let mut decompressed_bytes = Vec::new();
+        std::io::copy(&mut decoder, &mut decompressed_bytes).unwrap();
+
+        bincode::deserialize(decompressed_bytes.as_slice()).unwrap()
+    }
+}
+
+// ████████╗███████╗███████╗████████╗███████╗
+// ╚══██╔══╝██╔════╝██╔════╝╚══██╔══╝██╔════╝
+//    ██║   █████╗  ███████╗   ██║   ███████╗
+//    ██║   ██╔══╝  ╚════██║   ██║   ╚════██║
+//    ██║   ███████╗███████║   ██║   ███████║
+//    ╚═╝   ╚══════╝╚══════╝   ╚═╝   ╚══════╝
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct Foo(Vec<i32>);
+
+    #[test]
+    fn compress_and_decompress_serializable_type() {
+        let foo = Foo((0..100).collect());
+
+        let compressed_foo = foo.compress(BincodeSnappy);
+
+        let decompressed_foo = compressed_foo.decompress();
+
+        assert_eq!(foo, decompressed_foo);
+    }
+}

--- a/src/compressible_map.rs
+++ b/src/compressible_map.rs
@@ -6,6 +6,8 @@ use crate::{
 
 #[cfg(feature = "bincode_lz4")]
 use crate::BincodeLz4;
+#[cfg(feature = "bincode_snappy")]
+use crate::BincodeSnappy;
 
 use std::collections::{hash_map::RandomState, HashMap};
 use std::hash::{BuildHasher, Hash};
@@ -45,6 +47,22 @@ where
             cache: LruCache::default(),
             compressed: HashMap::default(),
             compression_params: BincodeLz4 { level },
+        }
+    }
+}
+
+#[cfg(feature = "bincode_snappy")]
+impl<K, V, H> CompressibleMap<K, V, BincodeSnappy, H>
+where
+    K: Clone + Eq + Hash,
+    V: Compressible<BincodeSnappy>,
+    H: BuildHasher + Default,
+{
+    pub fn new_bincode_snappy() -> Self {
+        Self {
+            cache: LruCache::default(),
+            compressed: HashMap::default(),
+            compression_params: BincodeSnappy,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,13 @@ mod lru_cache;
 
 #[cfg(feature = "bincode_lz4")]
 mod bincode_lz4;
+#[cfg(feature = "bincode_snappy")]
+mod bincode_snappy;
 
 #[cfg(feature = "bincode_lz4")]
 pub use bincode_lz4::{BincodeLz4, BincodeLz4Compressed};
+#[cfg(feature = "bincode_snappy")]
+pub use bincode_snappy::{BincodeSnappy, BincodeSnappyCompressed};
 
 pub use crate::compressible_map::{CompressibleMap, MaybeCompressed};
 pub use local_cache::LocalCache;


### PR DESCRIPTION
Hi! Thanks for the neat repo.

I wanted to get your excellent building-blocks library running on WASM + webgl2 via bevy-webgl2, but lz4 can't be compiled for the wasm32-unknown-unknown target.

So I added rust-snappy as an alternative compression backend.
I'll be opening a similar PR against the building-blocks repo itself to be able to use this PR there, once I have that PR cleaned up a bit.